### PR TITLE
Build musllinux wheels

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -22,13 +22,13 @@ on:
 
 jobs:
   linux:
-    name: Python on Linux and target ${{ matrix.target }}
+    name: Python on Linux (libc) and target ${{ matrix.target }}
 
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        target: [x86_64, x86, aarch64]
+        target: [x86_64, x86, aarch64, armv7]
 
     steps:
       - name: Check out repository
@@ -49,7 +49,47 @@ jobs:
           manylinux: auto
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        # stay on v3 for now until https://github.com/actions/upload-artifact/issues/478 is resolved
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+  linux-musl:
+    name: Python on Linux (musl) and target ${{ matrix.platform.target }}
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        platform: [
+          { target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl" },
+          { target: "i686-unknown-linux-musl", image_tag: "i686-musl" },
+          { target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl" },
+          { target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf" },
+        ]
+    
+    container:
+      image: docker://messense/rust-musl-cross:${{ matrix.platform.image_tag }}
+      env:
+        CFLAGS_armv7_unknown_linux_musleabihf: '-mfpu=vfpv3-d16'
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist -i 3.8 3.9 3.10 3.11 3.12 pypy3.8 pypy3.9 pypy3.10
+          sccache: 'true'
+          manylinux: auto
+          container: off
+
+      - name: Upload wheels
+        # stay on v3 for now until https://github.com/actions/upload-artifact/issues/478 is resolved
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -82,7 +122,8 @@ jobs:
           sccache: 'true'
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        # stay on v3 for now until https://github.com/actions/upload-artifact/issues/478 is resolved
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -114,7 +155,8 @@ jobs:
           sccache: 'true'
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        # stay on v3 for now until https://github.com/actions/upload-artifact/issues/478 is resolved
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -128,7 +170,8 @@ jobs:
 
     steps:
       - name: Download wheels from previous jobs
-        uses: actions/download-artifact@v4
+        # stay on v3 for now until https://github.com/actions/upload-artifact/issues/478 is resolved
+        uses: actions/download-artifact@v3
         with:
           name: wheels
 


### PR DESCRIPTION
Fixes [lingua-py#213](https://github.com/pemistahl/lingua-py/issues/213).

This PR extends the python-release workflow to build and publish musllinux wheels.

A few notes:
* The actions `actions/upload-artifact` and `actions/download-artifact` had to be downgraded from v4 to v3 because of [this issue](https://github.com/actions/upload-artifact/issues/478). v4 does not allow multiple upload to the same artifact anymore.
* I took the liberty to add `armv7`. If that is not desirable feel free to remove it again.
* I introduced a build dependency to the container image [messense/rust-musl-cross](https://github.com/rust-cross/rust-musl-cross). If that is undesirable the images have to be built manually instead.
* This PR is heavily inspired by [this workflow](https://github.com/messense/auditwheel-symbols/blob/master/.github/workflows/CI.yml#L90) in messense/auditwheel-symbols.
* I already [tested the workflow](https://github.com/phihos/lingua-rs/actions/runs/8130565995) and the only job failing is the upload to PyPI which is to be expected. You can download the wheels [here](https://github.com/phihos/lingua-rs/actions/runs/8130565995/artifacts/1292834982). I installed one of the musl wheels in latest Alpine Linux and one of the glibc in latest Ubuntu. Both worked fine.