### PR TITLE
split input text into words in assert_language_detection_with_rules_works_correctly()

### DIFF
--- a/src/detector.rs
+++ b/src/detector.rs
@@ -2395,7 +2395,7 @@ mod tests {
         expected_language: Option<Language>,
     ) {
         let detected_language = detector_for_all_languages.detect_language_with_rules(
-            &vec![word.to_string()],
+            &split_text_into_words(word),
             &detector_for_all_languages.languages,
         );
         assert_eq!(


### PR DESCRIPTION
In the test for `assert_language_detection_with_rules_works_correctly()`, the words passed to `detect_language_with_rules` are always Vecs of length 1, but in actual calls, the text is split into words and passed.

https://github.com/pemistahl/lingua-rs/blob/7329a5378de2b11f4f60898da68e3a1f6ae544e0/src/detector.rs#L755

For example, `ヴェダイヤモンド` is split into words as `[“ヴ”, “ェ”, “ダ”, “イ”, “ヤ”, “モ”, “ン”, “ド”]`, so it is considered preferable to use `split_text_into_words` for the unit test of `detect_language_with_rules`.