### PR TITLE
Avoid monomorphization overhead of API convenience generics

### DIFF
--- a/src/detector.rs
+++ b/src/detector.rs
@@ -335,7 +335,7 @@ impl LanguageDetector {
     /// assert_eq!(detected_language, Some(English));
     /// ```
     pub fn detect_language_of<T: Into<String>>(&self, text: T) -> Option<Language> {
-        self.detect_language_from_languages(text, &self.languages)
+        self.detect_language_from_languages(&text.into(), &self.languages)
     }
 
     /// Detects the languages of all given input texts.
@@ -389,9 +389,9 @@ impl LanguageDetector {
             .collect()
     }
 
-    fn detect_language_from_languages<T: Into<String>>(
+    fn detect_language_from_languages(
         &self,
-        text: T,
+        text: &str,
         languages: &HashSet<Language>,
     ) -> Option<Language> {
         let confidence_values =
@@ -479,14 +479,16 @@ impl LanguageDetector {
     /// }
     /// ```
     pub fn detect_multiple_languages_of<T: Into<String>>(&self, text: T) -> Vec<DetectionResult> {
-        let text_str = text.into();
+        self.detect_multiple_languages_of_impl(&text.into())
+    }
 
-        if text_str.is_empty() {
+    fn detect_multiple_languages_of_impl(&self, text: &str) -> Vec<DetectionResult> {
+        if text.is_empty() {
             return vec![];
         }
 
         let tokens_without_whitespace = TOKENS_WITHOUT_WHITESPACE
-            .find_iter(&text_str)
+            .find_iter(&text)
             .map(|mat| mat.as_str())
             .collect_vec();
 
@@ -497,7 +499,7 @@ impl LanguageDetector {
         let mut results = vec![];
         let mut language_counts = HashMap::new();
 
-        let language = self.detect_language_of(&text_str);
+        let language = self.detect_language_from_languages(text, &self.languages);
         if let Some(lang) = language {
             increment_counter(&mut language_counts, lang, 1);
         }
@@ -506,7 +508,7 @@ impl LanguageDetector {
             if word.chars().count() < 5 {
                 continue;
             }
-            let language = self.detect_language_of(*word);
+            let language = self.detect_language_from_languages(word, &self.languages);
             if let Some(lang) = language {
                 increment_counter(&mut language_counts, lang, 1);
             }
@@ -520,7 +522,7 @@ impl LanguageDetector {
         if languages.len() == 1 {
             let result = DetectionResult {
                 start_index: 0,
-                end_index: text_str.len(),
+                end_index: text.len(),
                 word_count: tokens_without_whitespace.len(),
                 language: *languages.iter().next().unwrap(),
             };
@@ -531,8 +533,8 @@ impl LanguageDetector {
             let mut word_count = 0;
             let mut current_language = None;
 
-            let last_index = TOKENS_WITH_OPTIONAL_WHITESPACE.find_iter(&text_str).count() - 1;
-            let token_matches = TOKENS_WITH_OPTIONAL_WHITESPACE.find_iter(&text_str);
+            let last_index = TOKENS_WITH_OPTIONAL_WHITESPACE.find_iter(&text).count() - 1;
+            let token_matches = TOKENS_WITH_OPTIONAL_WHITESPACE.find_iter(&text);
 
             for (i, token_match) in token_matches.enumerate() {
                 let word = token_match.as_str();
@@ -566,7 +568,7 @@ impl LanguageDetector {
                     if let Some(current_lang) = current_language {
                         let result = DetectionResult {
                             start_index: current_start_index,
-                            end_index: text_str.len(),
+                            end_index: text.len(),
                             word_count,
                             language: current_lang,
                         };
@@ -680,7 +682,7 @@ impl LanguageDetector {
         &self,
         text: T,
     ) -> Vec<(Language, f64)> {
-        self.compute_language_confidence_values_for_languages(text, &self.languages)
+        self.compute_language_confidence_values_for_languages(&text.into(), &self.languages)
     }
 
     /// Computes confidence values for each language supported by this detector for all the given
@@ -751,9 +753,9 @@ impl LanguageDetector {
             .collect()
     }
 
-    fn compute_language_confidence_values_for_languages<T: Into<String>>(
+    fn compute_language_confidence_values_for_languages(
         &self,
-        text: T,
+        text: &str,
         languages: &HashSet<Language>,
     ) -> Vec<(Language, f64)> {
         let mut values = Vec::with_capacity(languages.len());
@@ -762,8 +764,7 @@ impl LanguageDetector {
             values.push((*language, 0.0));
         }
 
-        let text_str = text.into();
-        let words = split_text_into_words(&text_str);
+        let words = split_text_into_words(text);
 
         if words.is_empty() {
             return values;


### PR DESCRIPTION
Having a `T: Into<String>` bound at the API boundaries is convenient but it implies a certain overhead if the implementation is monomorphized multiple times even though there is not functional difference to whether it has access to `T` or just `&str`.

More generally speaking, using `&str` as the public type might be a better choice in any case as the implementation does not use ownership of `T` anywhere and taking a string slice would there offer the most efficient API contract, but that would be a braking change and hence I did not make it here.