### PR TITLE
Add feature flag for wasm-bindgen (fixes #529)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,8 +171,8 @@ whichlang = { version = "0.1.1", optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 ahash = { version = "0.8.12", default-features = false, features = ["std", "compile-time-rng"] }
-serde-wasm-bindgen = "0.6.5"
-wasm-bindgen = "0.2.104"
+serde-wasm-bindgen = { version = "0.6.5", optional = true}
+wasm-bindgen = { version ="0.2.104", optional = true}
 
 [workspace.dependencies]
 include_dir = "0.7.4"
@@ -207,6 +207,7 @@ default = [
 accuracy-reports = ["clap", "cld2", "indoc", "polars", "titlecase", "whatlang", "whichlang"]
 benchmark = ["cld2", "whatlang", "whichlang"]
 python = ["pyo3", "serde-pickle"]
+wasm-bindgen = ["dep:wasm-bindgen", "dep:serde-wasm-bindgen"]
 afrikaans = ["lingua-afrikaans-language-model"]
 albanian = ["lingua-albanian-language-model"]
 arabic = ["lingua-arabic-language-model"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,7 +413,7 @@ pub use detector::LanguageDetector;
 pub use isocode::{IsoCode639_1, IsoCode639_3};
 pub use language::Language;
 pub use result::DetectionResult;
-#[cfg(target_family = "wasm")]
+#[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
 pub use wasm::{
     ConfidenceValue, DetectionResult as WasmDetectionResult,
     LanguageDetectorBuilder as WasmLanguageDetectorBuilder,
@@ -436,7 +436,7 @@ mod writer;
 #[cfg(feature = "python")]
 mod python;
 
-#[cfg(target_family = "wasm")]
+#[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
 mod wasm;
 
 #[cfg(any(target_family = "wasm", feature = "python"))]


### PR DESCRIPTION
Wasm-bindgen is used for JS interop, but some Wasm environments like [extism](https://extism.org/) dont need it and fail to execute code which uses wasm-bindgen.