### PR TITLE
add dependency python3-dll-a

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,6 +1546,7 @@ dependencies = [
  "maplit",
  "polars",
  "pyo3",
+ "python3-dll-a",
  "rayon",
  "regex 1.12.2",
  "rstest",
@@ -3099,6 +3100,15 @@ dependencies = [
  "pyo3-build-config",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "python3-dll-a"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d80ba7540edb18890d444c5aa8e1f1f99b1bdf26fb26ae383135325f4a36042b"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ fst = "0.4.7"
 include_dir = "0.7.4"
 itertools = "0.14.0"
 maplit = "1.0.2"
+python3-dll-a = "0.2.15"
 regex = "1.12.2"
 serde = { version = "1.0.228", features = ["derive"] }
 strum = "0.27.2"


### PR DESCRIPTION
fix build in a `nix-build` sandbox
by adding [python3-dll-a](https://lib.rs/crates/python3-dll-a)

build script: [lingua-language-detector.nix](https://github.com/milahu/nur-packages/blob/master/pkgs/python3/pkgs/lingua-language-detector/default.nix)

the error was

```
$ nix-build . -A python3.pkgs.lingua-language-detector
this derivation will be built:
  /nix/store/a4931rgkjf3zz7gg54jljxy32h81jhgr-lingua-rs-1.8.0.drv
building '/nix/store/a4931rgkjf3zz7gg54jljxy32h81jhgr-lingua-rs-1.8.0.drv'...
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pypa-build-hook
Using pypaBuildPhase
Sourcing python-runtime-deps-check-hook
Using pythonRuntimeDepsCheckHook
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Running phase: unpackPhase
unpacking source archive /nix/store/xw0f4yv7jy9y6wbah16l3xzd2ysfzrzp-lingua-rs
source root is lingua-rs
Executing cargoSetupPostUnpackHook
Finished cargoSetupPostUnpackHook
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "lingua-rs/tests/web.rs"
Running phase: patchPhase
Executing cargoSetupPostPatchHook
Validating consistency between /build/lingua-rs/Cargo.lock and /build/lingua-rs-1.8.0-vendor/Cargo.lock
Finished cargoSetupPostPatchHook
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
Executing maturinBuildHook
maturinBuildHook flags: --jobs=6 --offline --target x86_64-unknown-linux-gnu --manylinux off --strip --out /build/lingua-rs/dist --interpreter python3.13 --release
error: no matching package named `python3-dll-a` found
location searched: directory source `/build/lingua-rs-1.8.0-vendor/source-registry-0` (which is replacing registry `crates-io`)
required by package `pyo3-build-config v0.27.2`
    ... which satisfies dependency `pyo3-build-config = "=0.27.2"` (locked to 0.27.2) of package `pyo3 v0.27.2`
    ... which satisfies dependency `pyo3 = "^0.27.2"` (locked to 0.27.2) of package `lingua v1.8.0 (/build/lingua-rs)`
As a reminder, you're using offline mode (--offline) which can sometimes cause surprising resolution failures, if this error is too confusing you may wish to retry without `--offline`.
💥 maturin failed
  Caused by: Cargo metadata failed. Does your crate compile with `cargo build`?
  Caused by: `cargo metadata` exited with an error: 
error: Cannot build '/nix/store/a4931rgkjf3zz7gg54jljxy32h81jhgr-lingua-rs-1.8.0.drv'.
```

the fix is based on

- https://github.com/jawah/qh3/issues/37#issuecomment-2268293869