### PR TITLE
More informative panic message when you try to train on data that is too short

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -155,6 +155,11 @@ impl TrainingDataLanguageModel {
         for line in text.iter() {
             let chars = line.to_lowercase().chars().collect_vec();
 
+            assert!(
+                chars.len() >= ngram_length,
+                "input text must be at least {} chars",
+                ngram_length
+            );
             for i in 0..=chars.len() - ngram_length {
                 let slice = &chars[i..i + ngram_length].iter().collect::<String>();
 
@@ -569,6 +574,18 @@ mod tests {
 
             assert_eq!(model.absolute_frequencies, expected_absolute_frequencies);
             assert_eq!(model.ngram_probability_model, expected_probability_model);
+        }
+
+        #[test]
+        #[should_panic = "input text must be at least 5 chars"]
+        fn test_ngram_model_creation_panics_when_given_extremely_short_input() {
+            TrainingDataLanguageModel::from_text(
+                &["abcd"],
+                &Language::English,
+                5,
+                "\\p{L}&&\\p{Latin}",
+                &HashMap::new(),
+            );
         }
     }
 


### PR DESCRIPTION
Thanks so much for this cool project!

While experimenting with it locally, I attempted to create a new language model with `create_and_write_language_model_files`, and got a panic with the somewhat mysterious message:

```
attempt to subtract with overflow
```

It was because my input file had a line with only 4 characters, but the model creation was trying to extract a five-gram.

In case it is useful, here is a PR to provide a (for me, at least) more useful panic message -- please feel free to close this pr if it is not helpful!

```
input text must be at least 5 chars
```